### PR TITLE
Use requests instead of wget to download files (Issue #5)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     ],
     package_dir={"": "src"},
     packages=find_packages(where="src"),
-    install_requires=["wget >= 3.2"],
+    install_requires=["requests >= 2.26", "tqdm >= 4.62"],
     include_package_data=True,
     zip_safe=False,
 )

--- a/src/mwsql/utils.py
+++ b/src/mwsql/utils.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Iterator, Optional, TextIO, Union
 from urllib.error import HTTPError
 
-import wget  # type: ignore
+import requests  # type: ignore
 
 # Custom type
 PathObject = Union[str, Path]
@@ -129,12 +129,16 @@ def load(
         dump_file = Path(paws_root_dir, subdir, file_path)
 
     else:
-        url = f"{dumps_url}{str(subdir)}/{str(file_path)}"
+        url = f"{dumps_url}{str(subdir)}/{str(extended_filename)}"
         try:
-            print(f"Downloading {url}")
-            dump_file = wget.download(url, bar=_progress_bar)
+            response = requests.get(url)
+            response.raise_for_status()
+            response.encoding = "utf-8"
+            with open(file_path, "wb") as f:
+                f.write(response.content)
+            dump_file = file_path
         except HTTPError as e:
-            print(f"HTTPError: {e}")
-            raise
+            print(f"Error downloading {extended_filename}: {e}")
+            return None
 
     return Path(dump_file)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path, PosixPath
 
 import pytest
-from requests.exceptions import HTTPError
+import requests
 
 from mwsql.utils import _open_file, head, load
 
@@ -45,7 +45,7 @@ def test_load(database, filename, date, extension, expected):
 
 
 def test_load_HTTPError():
-    with pytest.raises(HTTPError):
+    with pytest.raises(requests.exceptions.HTTPError):
         load("simplewiki", "non-existing-filename", "latest")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,15 @@
 import os
 from pathlib import Path, PosixPath
-from urllib.error import HTTPError
 
 import pytest
+from requests.exceptions import HTTPError
 
 from mwsql.utils import _open_file, head, load
 
 from .helpers import Capturing
+
+# from urllib.error import HTTPError
+
 
 CURRENT_DIR = Path(__file__).parent
 DATA_DIR = CURRENT_DIR.parent / "data"


### PR DESCRIPTION
Download of dump files are now handled using `requests` instead of the deprecated `wget` module. The progress bar is now displayed using `tqdm`.