### PR TITLE
Windows compatibility changes (path separator, max int size)

### DIFF
--- a/src/mwsql/dump.py
+++ b/src/mwsql/dump.py
@@ -17,7 +17,7 @@ from .parser import (
 from .utils import _open_file
 
 # Allow long field names
-csv.field_size_limit(sys.maxsize)
+csv.field_size_limit(min(sys.maxsize, 2147483647))
 
 # Custom types
 PathObject = Union[str, Path]

--- a/src/mwsql/utils.py
+++ b/src/mwsql/utils.py
@@ -127,5 +127,6 @@ def load(
         return Path(paws_root_dir, subdir, file_path)
 
     else:
-        url = f"{dumps_url}{str(subdir)}/{str(extended_filename)}"
+        subdir_str = str(subdir).replace('\\', '/')
+        url = f"{dumps_url}{subdir_str}/{str(extended_filename)}"
         return download_file(url, extended_filename)

--- a/src/mwsql/utils.py
+++ b/src/mwsql/utils.py
@@ -127,6 +127,6 @@ def load(
         return Path(paws_root_dir, subdir, file_path)
 
     else:
-        subdir_str = str(subdir).replace('\\', '/')
+        subdir_str = str(subdir).replace("\\", "/")
         url = f"{dumps_url}{subdir_str}/{str(extended_filename)}"
         return download_file(url, extended_filename)


### PR DESCRIPTION
This PR aims to make this library compatible with Windows 10.

Closes #23.

When trying to use this library on Windows, I got the following errors:

First error:
```
>>> from mwsql import load
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Paul\AppData\Local\Programs\Python\Python310\lib\site-packages\mwsql\__init__.py", line 17, in <module>
    from .dump import Dump
  File "C:\Users\Paul\AppData\Local\Programs\Python\Python310\lib\site-packages\mwsql\dump.py", line 20, in <module>
    csv.field_size_limit(sys.maxsize)
OverflowError: Python int too large to convert to C long
```

This is because the underlying datatype being used by the csv library is a C long, which has a maximum size of `2,147,483,647`. Instead of always using the system's maxsize (which is `9223372036854775807` on 64-bit Windows 10) for setting the max CSV field size, I'm using the minimum between that and the maximum for a C long. That change allowed the `mwsql` library to be loaded.

Second error:
```
>>> dump_file = load('enwiki', 'page')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Paul\AppData\Local\Programs\Python\Python310\lib\site-packages\mwsql\utils.py", line 131, in load
    return download_file(url, extended_filename)
  File "C:\Users\Paul\AppData\Local\Programs\Python\Python310\lib\site-packages\mwsql\utils.py", line 78, in download_file
    response.raise_for_status()
  File "C:\Users\Paul\AppData\Local\Programs\Python\Python310\lib\site-packages\requests\models.py", line 960, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://dumps.wikimedia.org/enwiki%5Clatest/enwiki-latest-page.sql.gz
```

This is because on Windows, `pathlib`'s `Path` separator is a backslash (`\`), but the Path for the `subdir` is converted directly to a String and plugged into the request URL. Instead, I perform a naive find/replace on a backslash before plugging the subdir str into the URL. I'm open to any more elegant solutions. :) That change allowed me to successfully use the `load` method.

I hope these changes are helpful - thank you for helping maintain this great tool!