### PR TITLE
update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,13 @@ ci:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.12.0
     hooks:
       - id: black
         language_version: python3.9
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
         # args: ["--profile", "black", "--filter-files"]
@@ -26,21 +26,21 @@ repos:
         files: \.py$
         language_version: python3.9
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         language_version: python3.9
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.991
     hooks:
       - id: mypy
         exclude: ^tests/
         args: [--disallow-untyped-defs, --disallow-untyped-calls, --check-untyped-defs]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
* Updates all pre-commit hooks to the latest versions
* Change repo url for flake8 from GitLab to GitHub (https://www.reddit.com/r/Python/comments/yvfww8/flake8_took_down_the_gitlab_repository_in_favor/)